### PR TITLE
Crash in Receipt.initialize method when using wrong token

### DIFF
--- a/lib/monza/client.rb
+++ b/lib/monza/client.rb
@@ -39,7 +39,6 @@ module Monza
           nil
         end
       else
-        puts status
         raise VerificationResponse::VerificationError.new(status)
       end
 

--- a/lib/monza/client.rb
+++ b/lib/monza/client.rb
@@ -33,7 +33,11 @@ module Monza
 
       case status
       when 0
-        return VerificationResponse.new(json_response)
+        begin
+          return VerificationResponse.new(json_response)
+        rescue
+          nil
+        end
       else
         puts status
         raise VerificationResponse::VerificationError.new(status)


### PR DESCRIPTION
Hi,

I was using (apparently) wrong base64 data (from trans.transactionReceipt) and got a JSON response without all necessary fields. That caused crash somewhere in Monza::Receipt.initialize method. When using right base64 data (from receiptData) everything went perfect.

I don't know if this is the right way to fix that, but at least it not crashing anymore. If you want to have test case for this, base64 encoded response from https://gist.github.com/sauloarruda/2559455 will trigger this issue.