### PR TITLE
Fix Fixnum deprecated for ruby 2.4

### DIFF
--- a/lib/monza/bool_typecasting.rb
+++ b/lib/monza/bool_typecasting.rb
@@ -7,7 +7,12 @@ class String
   #  if using Rails empty? can be changed for blank?
 end
 
-class Fixnum
+if RUBY_VERSION >= "2.4"
+  integer_class = Object.const_get("Integer")
+else
+  integer_class = Object.const_get("Fixnum")
+end
+integer_class::class_eval do
   def to_bool
     return true if self == 1
     return false if self == 0


### PR DESCRIPTION
With ruby 2.4 Fixnum is deprecated [https://www.ruby-lang.org/en/news/2016/12/25/ruby-2-4-0-released/](https://www.ruby-lang.org/en/news/2016/12/25/ruby-2-4-0-released/)