### PR TITLE
Set Time.zone_default

### DIFF
--- a/lib/monza/config.rb
+++ b/lib/monza/config.rb
@@ -5,7 +5,6 @@ module Monza
 
   # Set default for Time zone if none has been set
   # Default is UTC
-  Time.zone = Time.zone ? Time.zone : "UTC"
-
+  Time.zone_default ||= Time.find_zone!("UTC")
 
 end

--- a/spec/monza_spec.rb
+++ b/spec/monza_spec.rb
@@ -5,6 +5,11 @@ describe Monza do
     expect(Monza::VERSION).not_to be nil
   end
 
+  it 'time zone' do
+    expect(Thread.current[:time_zone]).to be nil
+    expect(Time.zone_default).not_to be nil
+  end
+
   # it 'does something useful' do
   #   expect(false).to eq(true)
   # end


### PR DESCRIPTION
Hi!
I use this gem in my projects, Thanks!

But, I have a problem.

 in rails config

```
class Application < Rails::Application
  config.time_zone = 'Tokyo'
end
```

=> set Time.zone_default, so Time.zone access zone_default without current time_zone

https://github.com/rails/rails/blob/cfb1e4dfd8813d3d5c75a15a750b3c53eebdea65/activesupport/lib/active_support/core_ext/time/zones.rb#L15

However, in monza config

```
Time.zone = Time.zone ? Time.zone : "UTC"
```

So, monza updates not zone_default but current time_zone.
Therefore, even if the I set zone_default is 'Tokyo'  in rails config, Time.zone will become 'UTC' in my application.

Please confirm!

🙇 