### PR TITLE
Add support for "old-style" receipts

### DIFF
--- a/lib/monza/receipt.rb
+++ b/lib/monza/receipt.rb
@@ -38,12 +38,14 @@ module Monza
       @bundle_id = attributes['bundle_id']
       @application_version = attributes['application_version']
       @download_id = attributes['download_id']
-      @receipt_creation_date = DateTime.parse(attributes['receipt_creation_date'])
-      @receipt_creation_date_ms = Time.zone.at(attributes['receipt_creation_date_ms'].to_i / 1000)
-      @receipt_creation_date_pst = DateTime.parse(attributes['receipt_creation_date_pst'].gsub("America/Los_Angeles","PST"))
-      @request_date = DateTime.parse(attributes['request_date'])
-      @request_date_ms = Time.zone.at(attributes['request_date_ms'].to_i / 1000)
-      @request_date_pst = DateTime.parse(attributes['request_date_pst'].gsub("America/Los_Angeles","PST"))
+
+      @receipt_creation_date = DateTime.parse(attributes['receipt_creation_date']) rescue nil
+      @receipt_creation_date_ms = Time.zone.at(attributes['receipt_creation_date_ms'].to_i / 1000) rescue nil
+      @receipt_creation_date_pst = DateTime.parse(attributes['receipt_creation_date_pst'].gsub("America/Los_Angeles","PST")) rescue nil
+      @request_date = DateTime.parse(attributes['request_date']) rescue nil
+      @request_date_ms = Time.zone.at(attributes['request_date_ms'].to_i / 1000) rescue nil
+      @request_date_pst = DateTime.parse(attributes['request_date_pst'].gsub("America/Los_Angeles","PST")) rescue nil
+
       @original_purchase_date = DateTime.parse(attributes['original_purchase_date'])
       @original_purchase_date_ms = Time.zone.at(attributes['original_purchase_date_ms'].to_i / 1000)
       @original_purchase_date_pst = DateTime.parse(attributes['original_purchase_date_pst'].gsub("America/Los_Angeles","PST"))

--- a/lib/monza/transaction_receipt.rb
+++ b/lib/monza/transaction_receipt.rb
@@ -38,10 +38,18 @@ module Monza
       @web_order_line_item_id = attributes['web_order_line_item_id']
 
       if attributes['expires_date']
-        @expires_date = DateTime.parse(attributes['expires_date'])
+        begin
+          # Attempt to parse as RFC 3339 timestamp (new-style receipt)
+          @expires_date = DateTime.parse(attributes['expires_date'])
+        rescue
+          # Attempt to parse as integer ms epoch (old-style receipt)
+          @expires_date = Time.at(attributes['expires_date'].to_i / 1000).to_datetime
+        end
       end
       if attributes['expires_date_ms']
         @expires_date_ms = Time.zone.at(attributes['expires_date_ms'].to_i / 1000)
+      elsif attributes['expires_date']
+        @expires_date_ms = Time.zone.at(attributes['expires_date'].to_i / 1000)
       end
       if attributes['expires_date_pst']
         @expires_date_pst = DateTime.parse(attributes['expires_date_pst'].gsub("America/Los_Angeles","PST"))

--- a/lib/monza/verification_response.rb
+++ b/lib/monza/verification_response.rb
@@ -18,10 +18,13 @@ module Monza
       @environment = attributes['environment']
       @receipt = Receipt.new(attributes['receipt'])
       @latest_receipt_info = []
-      if attributes['latest_receipt_info']
+      case attributes['latest_receipt_info']
+      when Array
         attributes['latest_receipt_info'].each do |transaction_receipt_attributes|
           @latest_receipt_info << TransactionReceipt.new(transaction_receipt_attributes)
         end
+      when Hash
+        @latest_receipt_info << TransactionReceipt.new(attributes['latest_receipt_info'])
       end
       @latest_receipt = attributes['latest_receipt']
     end


### PR DESCRIPTION
Apple frequently replies to the verify-call
with an older receipt format in which various
fields that Monza expects are either absent
or of a different datatype.