### PR TITLE
Add is_in_intro_offer_period and subscription_group_identifier to TransactionReceipt

### DIFF
--- a/lib/monza/transaction_receipt.rb
+++ b/lib/monza/transaction_receipt.rb
@@ -22,6 +22,7 @@ module Monza
     attr_reader :expires_date_ms
     attr_reader :expires_date_pst
     attr_reader :is_trial_period
+    attr_reader :is_in_intro_offer_period
     attr_reader :cancellation_date
 
     def initialize(attributes)
@@ -56,6 +57,9 @@ module Monza
       end
       if attributes['is_trial_period']
         @is_trial_period = attributes['is_trial_period'].to_bool
+      end
+      if attributes['is_in_intro_offer_period']
+        @is_in_intro_offer_period = attributes['is_in_intro_offer_period'].to_bool
       end
       if attributes['cancellation_date']
         @cancellation_date = DateTime.parse(attributes['cancellation_date'])

--- a/lib/monza/transaction_receipt.rb
+++ b/lib/monza/transaction_receipt.rb
@@ -23,6 +23,7 @@ module Monza
     attr_reader :expires_date_pst
     attr_reader :is_trial_period
     attr_reader :is_in_intro_offer_period
+    attr_reader :subscription_group_identifier
     attr_reader :cancellation_date
 
     def initialize(attributes)
@@ -60,6 +61,9 @@ module Monza
       end
       if attributes['is_in_intro_offer_period']
         @is_in_intro_offer_period = attributes['is_in_intro_offer_period'].to_bool
+      end
+      if attributes['subscription_group_identifier']
+        @subscription_group_identifier = attributes['subscription_group_identifier']
       end
       if attributes['cancellation_date']
         @cancellation_date = DateTime.parse(attributes['cancellation_date'])

--- a/spec/response.json
+++ b/spec/response.json
@@ -35,7 +35,8 @@
         "expires_date_ms": "1466127448000",
         "expires_date_pst": "2016-06-16 18:37:28 America/Los_Angeles",
         "web_order_line_item_id": "1000000032727764",
-        "is_trial_period": "false"
+        "is_trial_period": "false",
+        "is_in_intro_offer_period": "false"
       }
     ]
   },
@@ -55,7 +56,9 @@
       "expires_date_ms": "1466127148000",
       "expires_date_pst": "2016-06-16 18:32:28 America/Los_Angeles",
       "web_order_line_item_id": "1000000032727765",
-      "is_trial_period": "true"
+      "is_trial_period": "true",
+      "is_in_intro_offer_period": "false",
+      "subscription_group_identifier": "12345678"
     }
   ],
   "latest_receipt": "base 64 string",


### PR DESCRIPTION
Additionally to is_trial_period there is also is_in_intro_offer_period and subscription_group_identifier returned by validation.
Both fields are necessary to check if the user is eligible for a free trial or introductory price within that subscription group.