### PR TITLE
Don't depend on last receipt, check max expiration

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,6 @@ You can also pass in `exclude_old_transactions` with value `true` as an option i
 # this checks if latest transaction receipt expiry_date is in today or the future
 response.is_subscription_active? # => true or false
 
-# Check if subscription is active
-# this checks if ANY transaction receipt expiry_date is in today or the future
-# this is helpful in case the most recent transaction was cancelled but the user still has a previous transaction or subscription that is active
-response.is_any_subscription_active? # => true or false
-
 # Returns the active subscription TransactionReceipt or nil
 response.latest_active_transaction_receipt # => TransactionReceipt instance
 

--- a/lib/monza/verification_response.rb
+++ b/lib/monza/verification_response.rb
@@ -37,30 +37,16 @@ module Monza
     end
 
     def is_subscription_active?
-      if @latest_receipt_info.last
-        if @latest_receipt_info.last.cancellation_date
-          false
-        else
-          @latest_receipt_info.last.expires_date_ms >= Time.zone.now
-        end
-      else
-        false
-      end
+      self.latest_active_transaction_receipt.present?
     end
 
+    # Deprecated, only left here for backwards compatibility, please use is_subscription_active?
     def is_any_subscription_active?
-      expires_dates_ms = @latest_receipt_info.reject(&:cancellation_date).map(&:expires_date_ms)
-      latest_expires_date_ms = expires_dates_ms.max
-
-      if latest_expires_date_ms
-        latest_expires_date_ms >= Time.zone.now
-      else
-        false
-      end
+      self.is_subscription_active?
     end
 
     def latest_active_transaction_receipt
-      latest_active_sub = @latest_receipt_info.sort_by(&:expires_date_ms).last
+      latest_active_sub = @latest_receipt_info.reject(&:cancellation_date).max_by(&:expires_date_ms)
 
       if latest_active_sub && latest_active_sub.expires_date_ms >= Time.zone.now
         return latest_active_sub

--- a/spec/response.json
+++ b/spec/response.json
@@ -43,6 +43,23 @@
     {
       "quantity": "1",
       "product_id": "com.example.product_id",
+      "transaction_id": "1000000218147501",
+      "original_transaction_id": "1000000218147501",
+      "purchase_date": "2016-06-17 01:27:28 Etc/GMT",
+      "purchase_date_ms": "1466126848000",
+      "purchase_date_pst": "2016-06-16 18:27:28 America/Los_Angeles",
+      "original_purchase_date": "2016-06-17 01:27:28 Etc/GMT",
+      "original_purchase_date_ms": "1466126848000",
+      "original_purchase_date_pst": "2016-06-16 18:27:28 America/Los_Angeles",
+      "expires_date": "2016-06-17 01:32:28 Etc/GMT",
+      "expires_date_ms": "1466127148000",
+      "expires_date_pst": "2016-06-16 18:32:28 America/Los_Angeles",
+      "web_order_line_item_id": "1000000032727765",
+      "is_trial_period": "true"
+    },
+    {
+      "quantity": "1",
+      "product_id": "com.example.product_id",
       "transaction_id": "1000000218147500",
       "original_transaction_id": "1000000218147500",
       "purchase_date": "2016-06-17 01:27:28 Etc/GMT",

--- a/spec/verification_response_spec.rb
+++ b/spec/verification_response_spec.rb
@@ -121,6 +121,45 @@ describe Monza::VerificationResponse do
         it { is_expected.to be false }
       end
     end
+
+    context 'when the receipts are not in order and the newest one is not the last' do
+      let(:verify) do
+        response["receipt"]["in_app"].each do |in_app|
+          replace_expires_date(in_app, 4.days.from_now)
+        end
+        response["latest_receipt_info"].each do |lri|
+          replace_expires_date(lri, 4.days.from_now)
+        end
+
+        # If this is the last receipt, change the expires date
+        replace_expires_date(response["latest_receipt_info"].last, 4.days.ago)
+
+        described_class.new(response)
+      end
+
+      context 'without cancellation date' do
+        it { is_expected.to be true }
+      end
+
+    end
+
+    context 'when there is no active receipt' do
+      let(:verify) do
+        response["receipt"]["in_app"].each do |in_app|
+          replace_expires_date(in_app, 4.days.ago)
+        end
+        response["latest_receipt_info"].each do |lri|
+          replace_expires_date(lri, 4.days.ago)
+        end
+
+        described_class.new(response)
+      end
+
+      context 'without cancellation date' do
+        it { is_expected.to be false }
+      end
+
+    end
   end
 
   describe 'is_any_subscription_active?' do


### PR DESCRIPTION
Apple does not guarantee the order of receipts within latest_receipt_info, so the active subscription might not be the last one in the array.

- is_subscription_active? will now check all receipt objects for the max 
expiration date and check that one