### PR TITLE
Preserve original attributes in transaction_receipt

### DIFF
--- a/lib/monza/transaction_receipt.rb
+++ b/lib/monza/transaction_receipt.rb
@@ -24,8 +24,10 @@ module Monza
     attr_reader :is_trial_period
     attr_reader :cancellation_date
     attr_reader :is_in_intro_offer_period
+    attr_reader :original_attributes
 
     def initialize(attributes)
+      @original_attributes = attributes
       @quantity = attributes['quantity'].to_i
       @product_id = attributes['product_id']
       @transaction_id = attributes['transaction_id']

--- a/spec/verification_response_spec.rb
+++ b/spec/verification_response_spec.rb
@@ -61,6 +61,8 @@ describe Monza::VerificationResponse do
       expect(latest_transaction.is_trial_period).to eq true
       expect(latest_transaction.is_in_intro_offer_period).to eq true
       expect(latest_transaction.cancellation_date).to be_nil
+
+      expect(latest_transaction.original_attributes).to be_present
     end
   end
 


### PR DESCRIPTION
The following idea replicates `original_json_response` in `VerificationResponse`.