### PR TITLE
Add missing cancellation attributes

### DIFF
--- a/lib/monza/transaction_receipt.rb
+++ b/lib/monza/transaction_receipt.rb
@@ -22,8 +22,8 @@ module Monza
     attr_reader :expires_date_ms
     attr_reader :expires_date_pst
     attr_reader :is_trial_period
-    attr_reader :cancellation_date
     attr_reader :cancellation_reason
+    attr_reader :cancellation_date
     attr_reader :cancellation_date_ms
     attr_reader :cancellation_date_pst
     attr_reader :is_in_intro_offer_period

--- a/lib/monza/transaction_receipt.rb
+++ b/lib/monza/transaction_receipt.rb
@@ -23,6 +23,9 @@ module Monza
     attr_reader :expires_date_pst
     attr_reader :is_trial_period
     attr_reader :cancellation_date
+    attr_reader :cancellation_reason
+    attr_reader :cancellation_date_ms
+    attr_reader :cancellation_date_pst
     attr_reader :is_in_intro_offer_period
 
     def initialize(attributes)
@@ -37,6 +40,10 @@ module Monza
       @original_purchase_date_ms = Time.zone.at(attributes['original_purchase_date_ms'].to_i / 1000)
       @original_purchase_date_pst = DateTime.parse(attributes['original_purchase_date_pst'].gsub("America/Los_Angeles","PST")) if attributes['original_purchase_date_pst']
       @web_order_line_item_id = attributes['web_order_line_item_id']
+      @cancellation_reason = attributes['cancellation_reason'] if attributes['cancellation_reason']
+      @cancellation_date = DateTime.parse(attributes['cancellation_date']) if attributes['cancellation_date']
+      @cancellation_date_ms = Time.zone.at(attributes['cancellation_date_ms'].to_i / 1000) if attributes['cancellation_date_ms']
+      @cancellation_date_pst = DateTime.parse(attributes['cancellation_date_pst'].gsub("America/Los_Angeles","PST")) if attributes['cancellation_date_pst']
 
       if attributes['expires_date']
         begin
@@ -60,9 +67,6 @@ module Monza
       end
       if attributes['is_in_intro_offer_period']
         @is_in_intro_offer_period = attributes['is_in_intro_offer_period'].to_bool
-      end
-      if attributes['cancellation_date']
-        @cancellation_date = DateTime.parse(attributes['cancellation_date'])
       end
     end # end initialize
 

--- a/spec/cancellation_response.json
+++ b/spec/cancellation_response.json
@@ -57,7 +57,10 @@
       "expires_date_pst": "2016-06-16 18:32:28 America/Los_Angeles",
       "web_order_line_item_id": "1000000032727765",
       "is_trial_period": "true",
-      "cancellation_date": "2016-06-17 01:37:28 Etc/GMT"
+      "cancellation_date": "2016-06-17 01:37:28 Etc/GMT",
+      "cancellation_date_ms": "1466127848000",
+      "cancellation_date_pst": "2016-06-16 18:37:28 America/Los_Angeles",
+      "cancellation_reason": "0"
     }
   ],
   "latest_receipt": "base 64 string"

--- a/spec/cancellation_response.json
+++ b/spec/cancellation_response.json
@@ -36,7 +36,10 @@
         "expires_date_pst": "2016-06-16 18:37:28 America/Los_Angeles",
         "web_order_line_item_id": "1000000032727764",
         "is_trial_period": "false",
-        "cancellation_date": "2016-06-17 01:37:28 Etc/GMT"
+        "cancellation_date": "2016-06-17 01:37:28 Etc/GMT",
+        "cancellation_date_ms": "1466127848000",
+        "cancellation_date_pst": "2016-06-16 18:37:28 America/Los_Angeles",
+        "cancellation_reason": "0"
       }
     ]
   },

--- a/spec/verification_response_spec.rb
+++ b/spec/verification_response_spec.rb
@@ -88,6 +88,9 @@ describe Monza::VerificationResponse do
 
       expect(latest_transaction.is_trial_period).to eq true
       expect(latest_transaction.cancellation_date).to eq DateTime.parse('2016-06-17 01:37:28 Etc/GMT')
+      expect(latest_transaction.cancellation_date_ms).to eq Time.zone.at("1466127848000".to_i / 1000)
+      expect(latest_transaction.cancellation_date_pst).to eq DateTime.parse("2016-06-16 18:37:28 PST")
+      expect(latest_transaction.cancellation_reason).to eq "0"
     end
   end
 


### PR DESCRIPTION
In my project I need to all cancellation fields from [latest_receipt_info](https://developer.apple.com/documentation/appstorereceipts/responsebody/latest_receipt_info)to be present. This PR adds these missing attributes.